### PR TITLE
Add model SNR normalization.

### DIFF
--- a/carmenes_barnard_star_tell/rv_content_new.ipynb
+++ b/carmenes_barnard_star_tell/rv_content_new.ipynb
@@ -1914,7 +1914,17 @@
    "execution_count": 20,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Normalize model to 100 snr in center of J band\n",
+    "\n",
+    "from eniric.snr_normalization import snr_constant_band\n",
+    "\n",
+    "snr_normalize = snr_constant_band(wav_sampled, flux_sampled, snr=100, band=\"J\", sampling=sampling)\n",
+    "flux_sampled = sampled_flux / snr_normalize\n",
+    "\n",
+    "print(\"Normalization constant\", snr_normalize)\n",
+    "convolved_model_interp = interpolate.interp1d(wav_sampled, flux_sampled)\n"
+   ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Scales model to SNR=100 at centre of J band (1.25 um).

Should now return close to paper precisions values.